### PR TITLE
Handle attachments with no content

### DIFF
--- a/lib/postmark/mitt.rb
+++ b/lib/postmark/mitt.rb
@@ -124,7 +124,9 @@ module Postmark
       def read
         @read ||= begin
           tempfile = MittTempfile.new(file_name, content_type)
-          tempfile.write(Base64.decode64(source["Content"]))
+          if size > 0
+            tempfile.write(Base64.decode64(source["Content"]))
+          end
           tempfile.rewind
           tempfile
         end

--- a/spec/postmark/mitt_spec.rb
+++ b/spec/postmark/mitt_spec.rb
@@ -146,6 +146,16 @@ describe Postmark::Mitt do
       it "should return the content if read" do
         attachment.read.read.should_not == ''
       end
+
+      it "should not blow up with a zero content length and no source" do
+        attachment = ::Postmark::Mitt::Attachment.new({"Name"=>"logo.gif",
+                                          "ContentType"=>"image/gif",
+                                          "ContentID"=>"logo.gif",
+                                          "ContentLength"=>0})
+        expect {
+          attachment.read.read
+        }.to_not raise_error
+      end
     end
 
     it "should have a size" do


### PR DESCRIPTION
This will stop things from blowing up in unpack. 