### PR TITLE
Escape file names in tempfile

### DIFF
--- a/lib/postmark/mitt.rb
+++ b/lib/postmark/mitt.rb
@@ -151,6 +151,7 @@ module Postmark
 
   class MittTempfile < Tempfile
     def initialize(basename, content_type, tmpdir=Dir::tmpdir)
+      basename = basename.gsub(/[\/\\]/, "-")
       if Postmark.ruby19?
         super(basename, tmpdir, :encoding => 'ascii-8bit')
       else

--- a/spec/postmark/mitt_spec.rb
+++ b/spec/postmark/mitt_spec.rb
@@ -168,4 +168,17 @@ describe Postmark::Mitt do
       attachment.size.should == 2000
     end
   end
+
+  describe ::Postmark::MittTempfile do
+    it "should not explode with path chars in the name" do
+      expect {
+        instance = ::Postmark::MittTempfile.new("file/with/../path", "text/csv")
+      }.to_not raise_error
+    end
+    
+    it "should escape path chars" do
+      instance = ::Postmark::MittTempfile.new("file/with/../path", "text/csv")
+      instance.path.should include("file-with-..-path")
+    end
+  end
 end


### PR DESCRIPTION
File names with path characters cause the tempfile to fail to write due to missing directories. This fixes the path names.