### PR TITLE
Be able to fetch `inbound_hash` value from email.to property

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -21,6 +21,7 @@ Postmark-mitt has been verified to work on Ruby Enterprise Edition 1.8.7, 1.9.2 
     email = Postmark::Mitt.new(request.body.read)
 
     email.to # "api-hash@inbound.postmarkapp.com"
+    email.inbound_hash # "api-hash"
     email.from # Bob Bobson <bob@bob.com>
     email.from_email # bob@bob.com
     email.text_body

--- a/lib/postmark/mitt.rb
+++ b/lib/postmark/mitt.rb
@@ -39,6 +39,10 @@ module Postmark
       to_full.any? ? to_full.first["Email"] : to
     end
 
+    def inbound_hash
+      to_full.any? ? to_email.split("@").first : to
+    end
+
     def to_name
       to_full.any? ? to_full.first["Name"] : to
     end

--- a/spec/postmark/mitt_spec.rb
+++ b/spec/postmark/mitt_spec.rb
@@ -29,6 +29,10 @@ describe Postmark::Mitt do
     mitt.to_email.should == "api-hash@inbound.postmarkapp.com"
   end
 
+  it "should pull out the to_inbound_hash" do
+    mitt.inbound_hash.should == "api-hash"
+  end
+
 
   it "should be from someone" do
     mitt.from.should == "Bob Bobson <bob@bob.com>"
@@ -175,7 +179,7 @@ describe Postmark::Mitt do
         instance = ::Postmark::MittTempfile.new("file/with/../path", "text/csv")
       }.to_not raise_error
     end
-    
+
     it "should escape path chars" do
       instance = ::Postmark::MittTempfile.new("file/with/../path", "text/csv")
       instance.path.should include("file-with-..-path")


### PR DESCRIPTION
It might be helpful for cases when [Postmark's Inbound Domain Forwarding](http://developer.postmarkapp.com/developer-process-domain.html) has been configured and something meaningful precedes inbound domain name. For example, I use it for defining publication level and messages from inbound email `private@inbound.domain.com` go private.