### PR TITLE
Add stripped_text_reply to Postmark::Mitt

### DIFF
--- a/lib/postmark/mitt.rb
+++ b/lib/postmark/mitt.rb
@@ -80,6 +80,10 @@ module Postmark
       source["TextBody"]
     end
 
+    def stripped_text_reply
+      source["StrippedTextReply"]
+    end
+
     def mailbox_hash
       source["MailboxHash"]
     end

--- a/spec/fixtures/email.json
+++ b/spec/fixtures/email.json
@@ -69,6 +69,7 @@
   "Subject": "Hi There",
   "Tag": "yourit",
   "TextBody": "\nThis is awesome!\n\n",
+  "StrippedTextReply": "This is awesome!",
   "To": "\"Api Hash\" <api-hash@inbound.postmarkapp.com>",
 	"ToFull": [
 		{

--- a/spec/postmark/mitt_spec.rb
+++ b/spec/postmark/mitt_spec.rb
@@ -17,6 +17,10 @@ describe Postmark::Mitt do
     mitt.text_body.should == "\nThis is awesome!\n\n"
   end
 
+  it "should have a stripped_text_reply" do
+    mitt.stripped_text_reply.should == "This is awesome!"
+  end
+
   it "should be to someone" do
     mitt.to.should == "Api Hash <api-hash@inbound.postmarkapp.com>"
   end


### PR DESCRIPTION
Recently Postmark added StrippedTextReply field where postmark attempts to parse the plain text portion of the reply
See https://postmarkapp.com/developer/user-guide/inbound/parse-an-email

It would be convenient to access StrippedTextReply field through mitt interface